### PR TITLE
Honor redirect status codes 307 and 308 in udc

### DIFF
--- a/src/lib/udc.c
+++ b/src/lib/udc.c
@@ -530,7 +530,7 @@ while (TRUE)
 	if (status == 206) 
 	    break;
 	}
-    if (status != 301 && status != 302)
+    if (status != 301 && status != 302 && status != 307 && status != 308)
 	return FALSE;
     ++redirectCount;
     if (redirectCount > 5)


### PR DESCRIPTION
URLs from ENCODE, such as such as https://www.encodeproject.org/files/ENCFF620UMO/@@download/ENCFF620UMO.bigWig can initially generate 307 redirect codes, which udc ignores, and therefore the read fails.

This PR makes udc recognize [307 and 308 codes](https://stackoverflow.com/a/42138726) in addition to 301 and 302.