### PR TITLE
Portability for musl libc

### DIFF
--- a/src/lib/fof.c
+++ b/src/lib/fof.c
@@ -336,7 +336,7 @@ static int cmpOnFilePos(const void *va, const void *vb)
 {
 const struct fofBatch *a = *((struct fofBatch **)va);
 const struct fofBatch *b = *((struct fofBatch **)vb);
-int dif = a->f - b->f;
+int dif = fileno(a->f) - fileno(b->f);
 if (dif == 0)
     dif = a->offset - b->offset;
 return dif;

--- a/src/lib/udc.c
+++ b/src/lib/udc.c
@@ -1001,9 +1001,9 @@ udcParseUrlFull(url, retProtocol, retAfterProtocol, retColon, NULL);
 
 static void addElementToDy(struct dyString *dy, char *name)
 /* add one element of a path to a dyString, hashing it if it's longer 
- * than MAXNAMLEN */
+ * than NAME_MAX */
 {
-if (strlen(name) > MAXNAMLEN)
+if (strlen(name) > pathconf(name, _PC_NAME_MAX))
     {
     unsigned char hash[SHA_DIGEST_LENGTH];
     char newName[(SHA_DIGEST_LENGTH + 1) * 2];
@@ -1018,7 +1018,7 @@ else
 }
 
 static char *longDirHash(char *name)
-/* take a path and hash the elements that are longer than MAXNAMLEN */
+/* take a path and hash the elements that are longer than NAME_MAX */
 {
 struct dyString *dy = newDyString(strlen(name));
 char *ptr = strchr(name, '/');


### PR DESCRIPTION
Minimal changes needed to build blat, gfClient, and gfServer on Alpine 3.12 (the same compile-time error for fof.c has been [previously reported for musl on Gentoo](https://bugs.gentoo.org/712652)).

I believe these suggested changes should be POSIX compliant. 