### PR TITLE
Fix linking Clang 11 compiled objects

### DIFF
--- a/src/inc/htmshell.h
+++ b/src/inc/htmshell.h
@@ -160,7 +160,7 @@ void htmlBadVar(char *varName);
 void htmlImage(char *fileName, int width, int height);
 /* Display centered image file. */
 
-jmp_buf htmlRecover;  /* Error recovery jump. Exposed for cart's use. */
+extern jmp_buf htmlRecover;  /* Error recovery jump. Exposed for cart's use. */
 
 void htmlVaWarn(char *format, va_list args);
 /* Write an error message.  (Generally you just call warn() or errAbort().


### PR DESCRIPTION
With Clang 11 htmlRecover from lib/htmshell.h is picked up as a
definition, not just declaration of the jmp_buf. As such both
lib/htmshell.c and hg/lib/cart.c export two symbols with the same name.