### PR TITLE
Update permissions on hgFixed.

### DIFF
--- a/src/product/installer/browserSetup.sh
+++ b/src/product/installer/browserSetup.sh
@@ -1742,7 +1742,8 @@ function downloadMinimal
     echo2 Copying hgFixed.trackVersion, required for most tracks
     $RSYNC --progress -avp $RSYNCOPTS $HGDOWNLOAD::mysql/hgFixed/trackVersion.* $MYSQLDIR/hgFixed/ 
     echo2 Copying hgFixed.refLink, required for RefSeq tracks across all species
-    $RSYNC --progress -avp $RSYNCOPTS $HGDOWNLOAD::mysql/hgFixed/refLink.* $MYSQLDIR/hgFixed/ 
+    $RSYNC --progress -avp $RSYNCOPTS $HGDOWNLOAD::mysql/hgFixed/refLink.* $MYSQLDIR/hgFixed/
+    chown -R $MYSQLUSER:$MYSQLUSER $MYSQLDIR/hgFixed
 
     startMysql
 


### PR DESCRIPTION
Permissions are modified on line 1739 with `chown -R $MYSQLUSER:$MYSQLUSER $MYSQLDIR/$db` , but not later for `$MYSQLDIR/hgFixed`.  This can cause permissions issues (especially if running as `root`), and this PR fixes that.