### PR TITLE
Wait on mysql server start and stop.

### DIFF
--- a/src/product/installer/browserSetup.sh
+++ b/src/product/installer/browserSetup.sh
@@ -1682,6 +1682,19 @@ function stopMysql
     else
         echo2 Could not find mysql nor mysqld file in /etc/init.d nor a systemd command. Please email genome-mirror@soe.ucsc.edu.
     fi
+
+    # Wait for up to 10 seconds for the service to go away.
+    for attempt in $(seq 1 10); do
+        mysqlcheck --all-databases
+        if [ $? -ne 0 ]; then
+            break
+        fi
+        sleep 1
+        if [[ attempt -eq 10 ]]; then
+            echo "Mysql appears to still be running, but continuing on anyway."
+            break
+        fi
+    done
 }
 
 # start the mysql database server
@@ -1700,6 +1713,19 @@ function startMysql
     else
         echo2 Could not find mysql nor mysqld file in /etc/init.d nor a systemd command. Please email genome-mirror@soe.ucsc.edu.
     fi
+
+    # Wait for up to 10 seconds for the service to be ready.
+    for attempt in $(seq 1 10); do
+        mysqlcheck --all-databases
+        if [ $? -eq 0 ]; then
+            break
+        fi
+        sleep 1
+        if [[ attempt -eq 10 ]]; then
+            echo "Mysql appears to not be running yet, but we're carrying on anyway."
+            break
+        fi
+    done
 }
 
 function mysqlCheck

--- a/src/product/installer/browserSetup.sh
+++ b/src/product/installer/browserSetup.sh
@@ -1742,7 +1742,8 @@ function downloadMinimal
     echo2 Copying hgFixed.trackVersion, required for most tracks
     $RSYNC --progress -avp $RSYNCOPTS $HGDOWNLOAD::mysql/hgFixed/trackVersion.* $MYSQLDIR/hgFixed/ 
     echo2 Copying hgFixed.refLink, required for RefSeq tracks across all species
-    $RSYNC --progress -avp $RSYNCOPTS $HGDOWNLOAD::mysql/hgFixed/refLink.* $MYSQLDIR/hgFixed/ 
+    $RSYNC --progress -avp $RSYNCOPTS $HGDOWNLOAD::mysql/hgFixed/refLink.* $MYSQLDIR/hgFixed/
+    chown -R $MYSQLUSER:$MYSQLUSER $MYSQLDIR/hgFixed
 
     startMysql
 


### PR DESCRIPTION
The startmysql function often returns before the server is fully operational and you get an error like:

```
Got error: 2002: Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (111 "Connection refused") when trying to connect
```

This PR solves that issue by waiting for a maximum of 10 seconds before continuing.