### PR TITLE
Fix chromToUcsc bug with online chromAlias files

### DIFF
--- a/src/utils/chromToUcsc/chromToUcsc
+++ b/src/utils/chromToUcsc/chromToUcsc
@@ -109,10 +109,8 @@ def parseAlias(fname):
     logging.debug("alias file is in IGV-format")
     toUcsc = {}
     if fname.startswith("http://") or fname.startswith("https://"):
-        ifh = urlopen(fname)
-        if fname.endswith(".gz"):
-            data = gzip.GzipFile(fileobj=ifh).read().decode()
-            ifh = data.splitlines()
+        data = downloadUrl(fname)
+        ifh = data.splitlines()
     elif fname.endswith(".gz"):
         ifh = gzip.open(fname, "rt")
     else:


### PR DESCRIPTION
The script crashes when using gzipped online chromAlias files on Python 2,

```
$ python2 chromToUcsc -a https://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/chromAlias.txt.gz
Traceback (most recent call last):
  File "chromToUcsc", line 279, in <module>
    main()
  File "chromToUcsc", line 277, in main
    chromToUcsc(aliasFname, fieldIdx, skipUnknown, ifh, ofh)
  File "chromToUcsc", line 145, in chromToUcsc
    toUcsc = parseAlias(aliasFname)
  File "chromToUcsc", line 114, in parseAlias
    data = gzip.GzipFile(fileobj=ifh).read().decode()
  File "/usr/local/lib/python2.7/gzip.py", line 260, in read
    self._read(readsize)
  File "/usr/local/lib/python2.7/gzip.py", line 294, in _read
    pos = self.fileobj.tell()   # Save current position
AttributeError: addinfourl instance has no attribute 'tell'
```

and uncompressed online chromAlias files on Python 3.

```
$ python3 chromToUcsc -a https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/latest/hg38.chromAlias.txt
Traceback (most recent call last):
  File "chromToUcsc", line 279, in <module>
    main()
  File "chromToUcsc", line 277, in main
    chromToUcsc(aliasFname, fieldIdx, skipUnknown, ifh, ofh)
  File "chromToUcsc", line 145, in chromToUcsc
    toUcsc = parseAlias(aliasFname)
  File "chromToUcsc", line 123, in parseAlias
    if line.startswith("#") and firstLine:
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

Utilize `downloadUrl` introduced in commit 2567ad8ce3a to fix the problem.

CC: @maximilianh 