### PR TITLE
netsyntenic -- avoid returning error for macos

### DIFF
--- a/src/hg/mouseStuff/netSyntenic/netSyntenic.c
+++ b/src/hg/mouseStuff/netSyntenic/netSyntenic.c
@@ -310,6 +310,8 @@ optionInit(&argc, argv, options);
 if (argc != 3)
     usage();
 netSyntenic(argv[1], argv[2]);
-printMem();
+#ifdef __linux__
+    printMem();
+#endif
 return 0;
 }


### PR DESCRIPTION
`/proc/self/stat` from L214 does not exist on macos

note that the synteny info is still added and this call is only executed after