### PR TITLE
jksql.c pointer typing in gcc13+

### DIFF
--- a/src/hg/lib/jksql.c
+++ b/src/hg/lib/jksql.c
@@ -1129,7 +1129,7 @@ mysql_options(conn, MYSQL_OPT_LOCAL_INFILE, NULL);
 if (sp->verifyServerCert && !sameString(sp->verifyServerCert,"0"))
     {
     #if !defined(MARIADB_VERSION_ID) && MYSQL_VERSION_ID >= 80000
-    mysql_options(conn, MYSQL_OPT_SSL_MODE, SSL_MODE_REQUIRED);
+    mysql_options(conn, MYSQL_OPT_SSL_MODE, (void*) SSL_MODE_REQUIRED);
     #else
     my_bool flag = TRUE;
     mysql_options(conn, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &flag);


### PR DESCRIPTION
This addresses a pointer type conversion error in jksql.c that is present when building against mysql (but not mariadb) with gcc13+