### PR TITLE
Update straw.cpp to enable compling with gcc-15

### DIFF
--- a/src/hg/lib/straw/straw.cpp
+++ b/src/hg/lib/straw/straw.cpp
@@ -31,6 +31,7 @@
 #include <utility>
 #include <vector>
 #include <streambuf>
+#include <cstdint>
 //#include <curl/curl.h>
 #include <iterator>
 #include <algorithm>


### PR DESCRIPTION
Because of these changes https://www.gnu.org/software//gcc/gcc-15/porting_to.html#header-dep-changes